### PR TITLE
Support for multiple values with the same key

### DIFF
--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -112,17 +112,6 @@ function _M.new(self)
         { __index = self })
 end
 
-function _M.get_all_for(self, key)
-    if not self._cookie then
-        return nil, "no cookie found in the current request"
-    end
-    if self.cookie_table == nil then
-        self.cookie_table = get_cookie_table(self._cookie)
-    end
-
-    return self.cookie_table[key]
-end
-
 function _M.get(self, key)
     if not self._cookie then
         return nil, "no cookie found in the current request"
@@ -156,6 +145,17 @@ function _M.get_all(self)
     end
 
     return self.last_value_cookie_table
+end
+
+function _M.get_all_for(self, key)
+    if not self._cookie then
+        return nil, "no cookie found in the current request"
+    end
+    if self.cookie_table == nil then
+        self.cookie_table = get_cookie_table(self._cookie)
+    end
+
+    return self.cookie_table[key]
 end
 
 function _M.get_cookie_size(self)

--- a/lib/resty/cookie.lua
+++ b/lib/resty/cookie.lua
@@ -72,7 +72,10 @@ local function get_cookie_table(text_cookie)
                     or byte(text_cookie, j) == HTAB
             then
                 value = sub(text_cookie, i, j - 1)
-                cookie_table[key] = value
+                if not cookie_table[key] then
+                    cookie_table[key] = {}
+                end
+                table.insert(cookie_table[key], value)
 
                 key, value = nil, nil
                 state = EXPECT_SP
@@ -91,7 +94,10 @@ local function get_cookie_table(text_cookie)
     end
 
     if key ~= nil and value == nil then
-        cookie_table[key] = sub(text_cookie, i)
+        if not cookie_table[key] then
+            cookie_table[key] = {}
+        end
+        table.insert(cookie_table[key], sub(text_cookie, i))
     end
 
     return cookie_table
@@ -106,7 +112,7 @@ function _M.new(self)
         { __index = self })
 end
 
-function _M.get(self, key)
+function _M.get_all_for(self, key)
     if not self._cookie then
         return nil, "no cookie found in the current request"
     end
@@ -117,16 +123,39 @@ function _M.get(self, key)
     return self.cookie_table[key]
 end
 
+function _M.get(self, key)
+    if not self._cookie then
+        return nil, "no cookie found in the current request"
+    end
+    if self.cookie_table == nil then
+        self.cookie_table = get_cookie_table(self._cookie)
+    end
+
+    local values = self.cookie_table[key]
+    if values then
+        return values[#values]
+    end
+
+    return nil
+end
+
 function _M.get_all(self)
     if not self._cookie then
         return nil, "no cookie found in the current request"
     end
 
-    if self.cookie_table == nil then
-        self.cookie_table = get_cookie_table(self._cookie)
+    if self.last_value_cookie_table == nil then
+        if self.cookie_table == nil then
+            self.cookie_table = get_cookie_table(self._cookie)
+        end
+        local last_value_cookie_table = {}
+        for key, values in pairs(self.cookie_table) do
+            last_value_cookie_table[key] = values[#values]
+        end
+        self.last_value_cookie_table = last_value_cookie_table
     end
 
-    return self.cookie_table
+    return self.last_value_cookie_table
 end
 
 function _M.get_cookie_size(self)


### PR DESCRIPTION
This PR introduces enhancements to the cookie handling functionality within this module. The changes aim to improve the module's ability to handle multiple values for the same cookie key.

### Changes:

- The cookie table, which stores keys to values, has been refactored to also keep keys to a list of values. The behavior of existing functions is preserved.. 
- Added a new function `get_all_for` to return all values for the given key
- Added unit tests

Test results:
```
make test
PATH=/usr/local/openresty/nginx/sbin:$PATH prove -I../test-nginx/lib -r t
t/sanity.t .. ok
All tests successful.
Files=1, Tests=126,  4 wallclock secs ( 0.02 usr  0.01 sys +  0.34 cusr  0.40 csys =  0.77 CPU)
Result: PASS
```